### PR TITLE
Correct copyright meta tag in head of SassConf website

### DIFF
--- a/website/source/partials/_head.erb
+++ b/website/source/partials/_head.erb
@@ -11,8 +11,8 @@
   <title>Sass Conf</title>
   <meta name="title" content="SassConf">
   <meta name="description" content="">
-  <meta name="author" content="Your Name Here">
-  <meta name="Copyright" content="Copyright Your Name Here 2011. All Rights Reserved.">
+  <meta name="author" content="SassConf Inc">
+  <meta name="Copyright" content="Copyright SassConf Inc 2013. All Rights Reserved.">
 
   <meta name="google-site-verification" content="">
 


### PR DESCRIPTION
Got the email today, had to check out the source, and noticed that the copyright meta information wasn't updated.
