### PR TITLE
Fixed volunteer link

### DIFF
--- a/website/source/partials/_footer.erb
+++ b/website/source/partials/_footer.erb
@@ -11,7 +11,7 @@
     <li><a href="https://twitter.com/adekunleoduye">Adekunle Oduye</a></li>
     <li><a href="https://twitter.com/bkjames">Robert James</a></li>
     <li><a href="https://twitter.com/skyefaerie">Aisha Green</a></li>
-    <li><a href="www.linkedin.com/in/lissaaguilar">Lissa Aguilar</a></li>
+    <li><a href="//www.linkedin.com/in/lissaaguilar">Lissa Aguilar</a></li>
     <li><a href="https://twitter.com/mashcode">Marc Shifflet</a></li>
   </ul>
   <ul>


### PR DESCRIPTION
Link didn't work without a protocol. Used // for "current protocol" but this could be forced to https://.
