### PR TITLE
Fix minor typo in the Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ In the spirit of open source this design process will be happening in public.
 
 ## Copyright
 
-While this may be open source and the website design is copyrighted. Feel free to dig into this and fork it to submit new design ideas, but **do not** steal the design for other websites and projects.
+While this may be open source, the website design is copyrighted. Feel free to dig into this and fork it to submit new design ideas, but **do not** steal the design for other websites and projects.


### PR DESCRIPTION
Minor typo in the `Readme.md` to clarify the legal ramifications of providing ideas in this repo.

This may be particularly useful for people evaluating how sharing ideas via this option by SassConf has been handled historically or if Github users deliberately view it years from now to analyze whether they should share ideas through similar ways of contributing in the future. 
